### PR TITLE
Upgrade to JDK 11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk9-openj9:jdk-9.181
+FROM adoptopenjdk/openjdk11-openj9:jdk-9.181
 RUN mkdir /opt/shareclasses
 RUN mkdir /opt/app
 COPY app.jar /opt/app


### PR DESCRIPTION
Users will almost certainly benefit from updating to the latest LTS major version of Java. It adds cgroup awareness, an essential feature on a container platform; generally improves performance; and is much less likely to break existing code than the migration from JDK 8 to 9 did.